### PR TITLE
fix: Missing power supply for Yeelight YLTD003

### DIFF
--- a/common/light/neopixelbus_psu.yaml
+++ b/common/light/neopixelbus_psu.yaml
@@ -1,0 +1,15 @@
+- platform: neopixelbus
+  name: "color_led"
+  id: color_led
+  variant: ${chipset}
+  pin: ${data_pin}
+  num_leds: ${num_leds}
+  type: ${rgb_order}
+  power_supply: power
+  color_correct: [$color_correct_r, $color_correct_g, $color_correct_b]
+  default_transition_length: ${default_transition_length}
+  gamma_correct: ${gamma_correct}
+  restore_mode: ${restore_mode}
+  <<: !include common/light/effects_adressable.yaml
+
+

--- a/yeelight_yltd003_01.yaml
+++ b/yeelight_yltd003_01.yaml
@@ -16,6 +16,7 @@ substitutions:
   output_cw_pin: GPIO12
   output_ww_pin: GPIO5
   status_led_pin: GPIO02 # Blue LED
+  power_supply_pin: GPIO4
 
   chipset: WS2812
   color_correct_r: 95%
@@ -44,6 +45,7 @@ esp8266:
 <<: !include common/api.yaml
 <<: !include common/ota.yaml
 <<: !include common/status_led.yaml
+<<: !include common/power_supply.yaml
 <<: !include common/syslog.yaml
 <<: !include common/time.yaml
 <<: !include common/webserver.yaml
@@ -61,15 +63,17 @@ binary_sensor:
 
 light:
   - !include common/light/cwww.yaml
-  - !include common/light/neopixelbus.yaml
+  - !include common/light/neopixelbus_psu.yaml
 
 output:
   - platform: esp8266_pwm
     pin: ${output_cw_pin}
     id: output_cw
+    power_supply: power
   - platform: esp8266_pwm
     pin: ${output_ww_pin}
     id: output_ww
+    power_supply: power
 
 sensor:
   - !include common/sensor/uptime.yaml


### PR DESCRIPTION
- Add power supply to cw/ww outputs.
- Add power supply controlled neopixelbus light common include variant.