### PR TITLE
fix: Underscore in device id

### DIFF
--- a/secrets.yaml.sample
+++ b/secrets.yaml.sample
@@ -25,31 +25,31 @@ miband_mac_address: 00:00:00:00:00:00
 miscale_mac_address: 00:00:00:00:00:00
 
 # Device secrets
-esp_bathroom_sensor_01_device_id: bathroom_sensor_01
+esp_bathroom_sensor_01_device_id: bathroom-sensor-01
 esp_bathroom_sensor_01_device_name: "Bathroom Sensor 01"
-esp_diy_hue_01_device_id: diy_hue_01
+esp_diy_hue_01_device_id: diy-hue-01
 esp_diy_hue_01_device_name: 'DIY Hue 01'
-esp_espcam_01_device_id: espcam_01
+esp_espcam_01_device_id: espcam-01
 esp_espcam_01_device_name: 'ESPCam 01'
-esp_gosund_sp111_01_device_id: gosund_sp111_01
+esp_gosund_sp111_01_device_id: gosund-sp111-01
 esp_gosund_sp111_01_device_name: "Gosund SP111 01"
-esp_koogeek_kloe4_01_device_id: koogeek_kloe4_01
+esp_koogeek_kloe4_01_device_id: koogeek-kloe4-01
 esp_koogeek_kloe4_01_device_name: "Koogeek KLOE4 01"
-esp_room_sensor_01_device_id: room_sensor_01
+esp_room_sensor_01_device_id: room-sensor-01
 esp_room_sensor_01_device_name: "Room Sensor 01"
-esp_shelly_1_light_01_device_id: shelly_1_light_01
+esp_shelly_1_light_01_device_id: shelly-1-light-01
 esp_shelly_1_light_01_device_name: "Shelly 1 Light 01"
-esp_shelly_1pm_01_device_id: shelly_1pm_01
+esp_shelly_1pm_01_device_id: shelly-1pm-01
 esp_shelly_1pm_01_device_name: "Shelly 1PM 01"
-esp_shelly_2_5_light_01_device_id: shelly_2_5_01
+esp_shelly_2_5_light_01_device_id: shelly-2-5-01
 esp_shelly_2_5_light_01_device_name: "Shelly 2.5 01"
-esp_sonoff_basic_01_device_id: sonoff_basic_01
+esp_sonoff_basic_01_device_id: sonoff-basic-01
 esp_sonoff_basic_01_device_name: "Sonoff Basic 01"
-esp_sonoff_s20_01_device_id: sonoff_s20_01
+esp_sonoff_s20_01_device_id: sonoff-s20-01
 esp_sonoff_s20_01_device_name: "Sonoff S20 01"
-esp_tuya_qs_d02_01_device_id: tuya_qs_d02_01
+esp_tuya_qs_d02_01_device_id: tuya-qs-d02-01
 esp_tuya_qs_d02_01_device_name: 'Tuya QS-D02 01'
 esp_ventilation_device_id: ventilation
 esp_ventilation_device_name: 'Ventilation'
-esp_yeelight_yltd003_01_device_id: yeelight_yltd003_01
+esp_yeelight_yltd003_01_device_id: yeelight-yltd003-01
 esp_yeelight_yltd003_01_device_name: 'Yeelight YLTD003 01'


### PR DESCRIPTION
- Use dash '-' instead of underscore '_' in device ids
- Resolve discouraged use of underscore in hostname warning